### PR TITLE
fix: parse latest valid result

### DIFF
--- a/src/__tests__/generate-notes.test.ts
+++ b/src/__tests__/generate-notes.test.ts
@@ -232,6 +232,32 @@ describe('generateNotes', () => {
     expect(promptArg).toContain('Custom template 1.0.0');
     expect(promptArg).toContain('Additional context information');
   });
+
+  it('should use the last valid JSON message when output contains invalid lines', async () => {
+    const execa = require('execa').default;
+
+    execa.mockImplementationOnce(() => {
+      const stdout = {
+        on: jest.fn().mockImplementation((event, cb) => {
+          if (event === 'data') {
+            cb('not-json\n');
+            cb(JSON.stringify({ role: 'assistant', type: 'message', content: 'First' }) + '\n');
+            cb('broken {\n');
+            cb(JSON.stringify({ role: 'system', result: '## Release Notes\n\nFinal' }) + '\n');
+          }
+          return stdout;
+        })
+      };
+
+      return {
+        stdout,
+        then: (cb) => Promise.resolve().then(() => cb())
+      };
+    });
+
+    const notes = await generateNotes({ cleanOutput: false }, mockContext);
+    expect(notes).toBe('## Release Notes\n\nFinal');
+  });
 });
 
 describe('extractReleaseNotes', () => {


### PR DESCRIPTION
## Summary
- ignore malformed lines when parsing Claude output
- fall back to 'General fixes and updates' only if no valid JSON is found
- test parser with mixed valid and invalid JSON lines

## Testing
- `npm test`
